### PR TITLE
Feature/pytest basic: Add basic Pytest integration to backend CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -26,6 +26,8 @@ jobs:
           done
           echo "API did not become healthy in time" >&2
           exit 1
+      - name: Run pytest
+        run: docker compose run --rm --no-deps backend pytest -q
       - name: Show logs on failure
         if: failure()
         run: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # העתקת קוד האפליקציה
 COPY ./app ./app
+COPY ./tests ./tests
 
 # הפעלת השרת
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,3 +26,5 @@ tzdata==2025.2
 uvicorn==0.35.0
 watchfiles==1.1.0
 websockets==15.0.1
+pytest
+httpx

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    response = client.get("/health/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_root_endpoint():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Hello" in response.text


### PR DESCRIPTION
### תיאור
הוספת שלב הרצת בדיקות Pytest ל־CI של ה־Backend.

### שינויים עיקריים
- עדכון workflow `.github/workflows/backend-ci.yml` להוספת שלב Run pytest.
- בדיקות בסיסיות (`test_health.py`) עוברות בהצלחה.
- נבדקה הרצה מקומית ו־GitHub Actions ירוק.

### בדיקות שבוצעו
- הרצת `docker compose run --rm --no-deps backend pytest -q` מקומית ✅
- ריצה מוצלחת של GitHub Actions ✅

### סיכום
שלב “בדיקות Pytest בסיסיות (Backend)” הושלם בהצלחה לפי הגאנט.
